### PR TITLE
feat!: support stubbed properties as well as methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A fork of [ts-sinon](https://www.npmjs.com/package/ts-sinon) that lets you BYO s
 Stub all object methods
 
 ```javascript
+import Sinon from 'sinon'
 import { stubObject } from 'ts-sinon'
 
 class Test {
@@ -40,31 +41,17 @@ expect(testStub.method()).to.equal('stubbed')
 Partial stub
 
 ```typescript
-class Test {
-  public someProp: string = 'test'
-  methodA() { return 'A: original' }
-  methodB() { return 'B: original' }
-}
+import Sinon from 'sinon'
+import { stubObject } from 'ts-sinon'
 
-const test = new Test()
-// second argument must be existing class method name, in this case only 'methodA' or 'methodB' are accepted.
-const testStub = stubObject<Test>(test, ['methodA'])
-
-expect(testStub.methodA()).to.be.undefined
-expect(testStub.methodB()).to.equal('B: original')
-```
-
-## Example
-
-Stub with predefined return values (type-safe)
-
-```typescript
 class Test {
   method() { return 'original' }
 }
 
 const test = new Test()
-const testStub = stubObject<Test>(test, { method: 'stubbed' })
+const testStub = stubObject<Test>(test, {
+  method: Sinon.stub().returns('stubbed')
+})
 
 expect(testStub.method()).to.equal('stubbed')
 ```
@@ -74,6 +61,7 @@ expect(testStub.method()).to.equal('stubbed')
 Interface stub (stub all methods)
 
 ```typescript
+import Sinon from 'sinon'
 import { stubInterface } from 'ts-sinon'
 
 interface Test {
@@ -94,12 +82,17 @@ expect(testStub.method()).to.equal('stubbed')
 Interface stub with predefined return values (type-safe)
 
 ```typescript
+import Sinon from 'sinon'
+import { stubInterface } from 'ts-sinon'
+
 interface Test {
   method(): string
 }
 
 // method property has to be the same type as method() return type
-const testStub = stubInterface<Test>({ method: 'stubbed' })
+const testStub = stubInterface<Test>({
+  method: Sinon.stub().returns('stubbed')
+})
 
 expect(testStub.method()).to.equal('stubbed')
 ```
@@ -111,6 +104,7 @@ Object constructor stub (stub all methods)
 - without passing predefined args to the constructor:
 
 ```typescript
+import Sinon from 'sinon'
 import { stubConstructor } from 'ts-sinon'
 
 class Test {
@@ -142,6 +136,9 @@ expect(testStub.someVar).to.equal(20)
 Passing predefined args to the constructor
 
 ```typescript
+import Sinon from 'sinon'
+import { stubConstructor } from 'ts-sinon'
+
 class Test {
   constructor(public someVar: string, y: boolean) {}
   // ...
@@ -151,18 +148,6 @@ class Test {
 const testStub = stubConstructor(Test, 'someValue', true)
 
 expect(testStub.someVar).to.equal('someValue')
-```
-
-## Sinon methods
-
-By importing 'ts-sinon' you have access to all sinon methods.
-
-```typescript
-import sinon, { stubInterface } from 'ts-sinon'
-
-const functionStub = sinon.stub()
-const spy = sinon.spy()
-// ...
 ```
 
 # Install

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
+    "dep-check": "aegir dep-check",
     "build": "aegir build",
     "test": "aegir test",
     "release": "aegir release",

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,7 @@ export function stubObject<T extends object> (object: T, partial?: Partial<T>): 
 
   if (partial != null) {
     for (const key in partial) {
-      if (excludedMethods.includes(key) === true) {
+      if (excludedMethods.includes(key)) {
         continue
       }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { chai } from 'aegir/chai'
 import sinonChai from 'sinon-chai'
 import { stubObject, stubInterface, stubConstructor } from '../src/index.js'
+import Sinon from 'sinon'
 
 chai.use(sinonChai)
 const expect = chai.expect
@@ -92,30 +93,6 @@ describe('ts-sinon', () => {
       })
     })
 
-    it('returns partial stub object with only "test" method stubbed when array with "test" has been given', () => {
-      const object = new class {
-        private readonly r: string
-        constructor () {
-          this.r = 'run'
-        }
-
-        test (): number {
-          return 123
-        }
-
-        run (): string {
-          return this.r
-        }
-      }()
-
-      const objectStub = stubObject(object, ['test'])
-
-      expect(objectStub.test()).to.be.undefined()
-      expect(objectStub.run()).to.equal('run')
-
-      expect(objectStub.test).to.have.been.called()
-    })
-
     it('returns partial stub object with "run" method stubbed and returning "some val" value when key value map { run: "some val" } has been given', () => {
       const object = new class {
         test (): number {
@@ -127,7 +104,9 @@ describe('ts-sinon', () => {
         }
       }()
 
-      const objectStub = stubObject(object, { run: 'some val' })
+      const objectStub = stubObject(object, {
+        run: Sinon.stub().returns('some val')
+      })
 
       expect(objectStub.run()).to.equal('some val')
       expect(objectStub.test()).to.equal(123)
@@ -153,12 +132,20 @@ describe('ts-sinon', () => {
       expect(stub.prop1).to.equal('x')
     })
 
+    it('sets an "x" value on "prop1" property from constructor', () => {
+      const stub = stubInterface<ITest>({
+        prop1: 'x'
+      })
+
+      expect(stub.prop1).to.equal('x')
+    })
+
     it('returns stub object created from interface with all methods stubbed with "method2" predefined to return value of "abc" and "method1" which is testable with expect that has been called', () => {
       const expectedMethod2Arg: number = 2
       const expectedMethod2ReturnValue = 'abc'
 
       const interfaceStub: ITest = stubInterface<ITest>({
-        method2: expectedMethod2ReturnValue
+        method2: Sinon.stub().returns(expectedMethod2ReturnValue)
       })
 
       const object = new class {
@@ -180,7 +167,7 @@ describe('ts-sinon', () => {
 
     it('returns stub object created from interface with all methods stubbed including "method2" predefined to return "x" when method map to value { method: x } has been given', () => {
       const interfaceStub: ITest = stubInterface<ITest>({
-        method2: 'test'
+        method2: Sinon.stub().returns('test')
       })
 
       const object = new class {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 import { chai } from 'aegir/chai'
+import Sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import { stubObject, stubInterface, stubConstructor } from '../src/index.js'
-import Sinon from 'sinon'
 
 chai.use(sinonChai)
 const expect = chai.expect


### PR DESCRIPTION
Changes the method map passed to `stubInterface` and friends to be a `Partial` of the stubbed type.

This way we can pass values for properties and `Sinon.stub`s for methods, which is usually better since we freqently want to stub behaviour as well as return types which we can't do when we're just passing values.

BREAKING CHANGE: method map values must now be wrapped in `Sinon.stub().returns()`